### PR TITLE
lookup: use byte literal instead of map

### DIFF
--- a/svb/lookup.go
+++ b/svb/lookup.go
@@ -17,7 +17,7 @@ package svb
 // lengths is the lookup table that is the shortcut to get from a control
 // byte to knowing the 4 individual data byte lengths (in index 0 - 3), as
 // well as the total data bytes needed for the given block (in index 4)
-var lookup = map[byte][4]uint8{
+var lookup = [...][4]uint8{
 	0x00: [4]uint8{1, 1, 1, 1},
 	0x01: [4]uint8{1, 1, 1, 2},
 	0x02: [4]uint8{1, 1, 1, 3},


### PR DESCRIPTION
This eliminates a runtime.mapaccess1 call (in favor of a memory access)
whereever lookup[ctrl] is used.